### PR TITLE
scanbuttond hp5590 backend: Use ISO C types

### DIFF
--- a/src/scanbuttond/backends/hp5590.c
+++ b/src/scanbuttond/backends/hp5590.c
@@ -268,17 +268,17 @@ scanbtnd_close(scanner_t* scanner)
 /* Structure describing control URB */
 struct usb_in_usb_ctrl_setup
 {
-       u_int8_t  bRequestType;
-       u_int8_t  bRequest;
-       u_int16_t wValue;
-       u_int16_t wIndex;
-       u_int16_t wLength;
+       uint8_t  bRequestType;
+       uint8_t  bRequest;
+       uint16_t wValue;
+       uint16_t wIndex;
+       uint16_t wLength;
 } __attribute__ ((packed));
 
 static int
 hp5590_get_ack (scanner_t *scanner)
 {
-       u_int8_t        status;
+       uint8_t        status;
        int                     ret;
 
        /* Check if USB-in-USB operation was accepted */
@@ -312,8 +312,8 @@ hp5590_control_msg (scanner_t *scanner,
        int                                                             ret;
        unsigned int                                    len;
        unsigned char                                   *ptr;
-       u_int8_t                                                ack;
-       u_int8_t                                                response;
+       uint8_t                                                ack;
+       uint8_t                                                response;
 
        /* IN (read) operation will be performed */
        if (requesttype & USB_DIR_IN)
@@ -478,7 +478,7 @@ hp5590_control_msg (scanner_t *scanner,
 static int
 hp5590_verify_last_cmd (scanner_t *scanner, unsigned int cmd)
 {
-       u_int16_t               verify_cmd;
+       uint16_t               verify_cmd;
        unsigned int    last_cmd;
        unsigned int    core_status;
        int                             ret;
@@ -534,7 +534,7 @@ int
 scanbtnd_get_button(scanner_t* scanner)
 {
        int             button = 0;
-       u_int16_t       button_status;
+       uint16_t       button_status;
        int                     ret;
 
        if (!scanner->is_open)


### PR DESCRIPTION
This patch is needed to build scanbd with enabled scanbuttond support on openwrt trunk.